### PR TITLE
Fix WebDAV for Windows (w strips tailing / for no apparent reason)

### DIFF
--- a/internal/infra/nethttp/router.go
+++ b/internal/infra/nethttp/router.go
@@ -47,7 +47,9 @@ func NewRouter(deps *service.Locator) http.Handler {
 		for _, m := range strings.Split("OPTIONS, MKCOL, LOCK, GET, HEAD, POST, DELETE, PROPPATCH, COPY, MOVE, UNLOCK, PROPFIND, PUT", ", ") {
 			chi.RegisterMethod(m)
 		}
-		s.Mount("/webdav/", webdav.NewHandler(deps.CtxdLogger(), deps.Settings()))
+		wh := webdav.NewHandler(deps.CtxdLogger(), deps.Settings())
+		s.Handle("/webdav", wh)
+		s.Mount("/webdav/", wh)
 		// End of WebDAV.
 
 		s.Post("/album", control.CreateAlbum(deps))

--- a/internal/infra/webdav/handler.go
+++ b/internal/infra/webdav/handler.go
@@ -10,7 +10,7 @@ import (
 
 func NewHandler(logger ctxd.Logger, cfg settings.Values) http.Handler {
 	handler := &webdav.Handler{
-		Prefix:     "/webdav/",
+		Prefix:     "/webdav",
 		FileSystem: webdav.Dir("."),
 		LockSystem: webdav.NewMemLS(),
 		Logger: func(r *http.Request, err error) {


### PR DESCRIPTION
When `https://vearutop.p1cs.art/webdav/` is used to connect WebDAV in Windows 10, Windows actually knocks into `https://vearutop.p1cs.art/webdav`.